### PR TITLE
Enabling Dependency Present events

### DIFF
--- a/luigi_monitor/luigi_monitor.py
+++ b/luigi_monitor/luigi_monitor.py
@@ -72,10 +72,7 @@ class SlackNotifications(object):
             if event == FAILURE:
                 event_tasks.append("Task: {}; Exception: {}".format(task['task'], task['exception']))
 
-            if event == MISSING:
-                event_tasks.append(task)
-
-            if event == PRESENT:
+            if event in [MISSING, PRESENT]:
                 event_tasks.append(task)
 
             if event == SUCCESS:

--- a/luigi_monitor/luigi_monitor.py
+++ b/luigi_monitor/luigi_monitor.py
@@ -14,7 +14,7 @@ PRESENT = 'Present'
 
 
 class SlackNotifications(object):
-    slack_events = [SUCCESS, FAILURE, MISSING]
+    slack_events = [SUCCESS, FAILURE, MISSING, PRESENT]
     events_message_cfg = {
         SUCCESS: {
             'title': 'Successes',
@@ -29,7 +29,7 @@ class SlackNotifications(object):
             'color': '#439FE0'
         },
         PRESENT: {
-            'title': 'Task(s) not run - already run or no new data to process',
+            'title': 'Task(s) not run (probably already run or no new data to process)',
             'color': '#f7a70a'
         }
     }
@@ -115,7 +115,6 @@ def missing(task):
 
 def present(task):
     task = str(task)
-
     if 'Present' in EVENTS:
         EVENTS['Present'].append(task)
     else:

--- a/luigi_monitor/luigi_monitor.py
+++ b/luigi_monitor/luigi_monitor.py
@@ -10,6 +10,7 @@ EVENTS = {}
 SUCCESS = 'Success'
 FAILURE = 'Failure'
 MISSING = 'Missing'
+PRESENT = 'Present'
 
 
 class SlackNotifications(object):
@@ -26,6 +27,10 @@ class SlackNotifications(object):
         MISSING: {
             'title': 'Tasks with missing dependencies',
             'color': '#439FE0'
+        },
+        PRESENT: {
+            'title': 'Task(s) not run - already run or no new data to process',
+            'color': '#f7a70a'
         }
     }
 
@@ -70,6 +75,9 @@ class SlackNotifications(object):
             if event == MISSING:
                 event_tasks.append(task)
 
+            if event == PRESENT:
+                event_tasks.append(task)
+
             if event == SUCCESS:
                 event_tasks.append("Task: {}".format(task['task']))
 
@@ -106,7 +114,12 @@ def missing(task):
 
 
 def present(task):
-    raise NotImplementedError
+    task = str(task)
+
+    if 'Present' in EVENTS:
+        EVENTS['Present'].append(task)
+    else:
+        EVENTS['Present'] = [task]
 
 
 def broken(task, exception):
@@ -142,6 +155,9 @@ def success(task):
     if 'Missing' in EVENTS:
         EVENTS['Missing'] = [missing for missing in EVENTS['Missing']
                              if task not in missing]
+    if 'Present' in EVENTS:
+        EVENTS['Present'] = [present for present in EVENTS['Present']
+                             if task not in present]
 
 
 def processing_time(task, time):
@@ -208,7 +224,7 @@ def send_message(slack_url, payload):
 
 
 @contextmanager
-def monitor(EVENTS=['FAILURE', 'DEPENDENCY_MISSING', 'SUCCESS'],
+def monitor(EVENTS=['FAILURE', 'DEPENDENCY_MISSING', 'SUCCESS', 'DEPENDENCY_PRESENT'],
             slack_url=None, max_print=10,
             job_name=os.path.basename(inspect.stack()[-1][1])):
     if EVENTS:

--- a/tests/test_slack_notifications.py
+++ b/tests/test_slack_notifications.py
@@ -4,6 +4,7 @@ from six import iteritems
 from luigi_monitor.luigi_monitor import (SUCCESS,
                                          FAILURE,
                                          MISSING,
+                                         PRESENT,
                                          SlackNotifications)
 
 
@@ -54,6 +55,8 @@ def expected_slack_attachments(request):
      [('Failures', 'danger', 'Task: FailureLuigiTask(); Exception: Exception()')]),
     # Missing slack attachment
     ({MISSING: ['MissingLuigiTask()']}, [('Tasks with missing dependencies', '#439FE0', 'MissingLuigiTask()')]),
+    # Present slack attachment
+    ({PRESENT: ['PresentLuigiTask()']}, [('Task(s) not run (probably already run or no new data to process)', '#f7a70a', 'PresentLuigiTask()')]),
     # Success + Success
     ({SUCCESS: [{'task': 'SuccessLuigiTask()'}, {'task': 'SuccessLuigiTask()'}]},
      [('Successes', 'good', 'Task: SuccessLuigiTask()\nTask: SuccessLuigiTask()')]),


### PR DESCRIPTION
- When tasks return an `[]` (empty list), this is picked up as "Dependency Present" event (this is the case with (luigi.WrapperTasks) - pretty much all our luigi flows
- Often - we return an `[]` as the task is not required to be run because it has already been run or there's no new data to process